### PR TITLE
Allow using league/oauth2-client v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,16 @@
         }
     ],
     "homepage": "https://github.com/daveismyname/laravel-microsoft-graph",
-    "keywords": ["Laravel", "MsGraph", "Graph", "Microsoft Graph", "Office365"],
+    "keywords": [
+        "Laravel",
+        "MsGraph",
+        "Graph",
+        "Microsoft Graph",
+        "Office365"
+    ],
     "require": {
         "illuminate/support": "5.5.x|5.6.x|5.7.x|5.8.x|6.x",
-        "league/oauth2-client": "^1.4",
+        "league/oauth2-client": "^1.4|^2",
         "guzzlehttp/guzzle": "^6"
     },
     "autoload": {


### PR DESCRIPTION
Hi, thanks for this package!

I'm using it in a project that already requires `league/oauth-client=^2`, which conflicts with the `^1.4` requirement.

I haven't noticed any issues with using the newer version, but I also haven't used all the features of this package yet, so... might be worth testing more thoroughly.