### PR TITLE
Fix issue when connecting with specified ID

### DIFF
--- a/src/MsGraph.php
+++ b/src/MsGraph.php
@@ -88,7 +88,7 @@ class MsGraph
                 $result = $this->storeToken($accessToken->getToken(), $accessToken->getRefreshToken(), $accessToken->getExpires(), $id);
 
                 //get user details
-                $me = Api::get('me', null, $id);
+                $me = Api::get('me', null, [], $id);
 
                 $event = [
                     'token_id' => $result->id,


### PR DESCRIPTION
When connecting with a specified user ID there was an error because the id was wrongly forwarded when fetching the user details for the first time. This was due to the __call-method having a new parameter added to it.

This pull request fixes that issue. 