### PR TITLE
feat: MsGraphAdmin add resource in params

### DIFF
--- a/src/MsGraph.php
+++ b/src/MsGraph.php
@@ -156,7 +156,7 @@ class MsGraph
     {
         //use id if passed otherwise use logged in user
         $id    = ($id) ? $id : auth()->id();
-        $token = MsGraphToken::where('user_id', $id)->latest()->first();
+        $token = MsGraphToken::where('user_id', $id)->whereNotNull('email')->latest()->first();
 
         // Check if tokens exist otherwise run the oauth request
         if (!isset($token->access_token)) {
@@ -204,7 +204,7 @@ class MsGraph
     public function getTokenData($id = null)
     {
         $id = ($id) ? $id : auth()->id();
-        return MsGraphToken::where('user_id', $id)->latest()->first();
+        return MsGraphToken::where('user_id', $id)->whereNotNull('email')->latest()->first();
     }
 
     /**

--- a/src/MsGraph.php
+++ b/src/MsGraph.php
@@ -156,7 +156,7 @@ class MsGraph
     {
         //use id if passed otherwise use logged in user
         $id    = ($id) ? $id : auth()->id();
-        $token = MsGraphToken::where('user_id', $id)->whereNotNull('email')->latest()->first();
+        $token = MsGraphToken::where('user_id', $id)->where('refresh_token', '<>', '')->latest()->first();
 
         // Check if tokens exist otherwise run the oauth request
         if (!isset($token->access_token)) {
@@ -204,7 +204,7 @@ class MsGraph
     public function getTokenData($id = null)
     {
         $id = ($id) ? $id : auth()->id();
-        return MsGraphToken::where('user_id', $id)->whereNotNull('email')->latest()->first();
+        return MsGraphToken::where('user_id', $id)->where('refresh_token', '<>', '')->latest()->first();
     }
 
     /**

--- a/src/MsGraphAdmin.php
+++ b/src/MsGraphAdmin.php
@@ -85,6 +85,7 @@ class MsGraphAdmin
                     'client_id'     => config('msgraph.clientId'),
                     'client_secret' => config('msgraph.clientSecret'),
                     'grant_type'    => 'client_credentials',
+                    'resource' => 'https://graph.microsoft.com',
                 ];
 
                 $token = $this->dopost(config('msgraph.tenantUrlAccessToken'), $params);
@@ -131,6 +132,7 @@ class MsGraphAdmin
                 'client_id'     => config('msgraph.clientId'),
                 'client_secret' => config('msgraph.clientSecret'),
                 'grant_type'    => 'client_credentials',
+                'resource' => 'https://graph.microsoft.com',
             ];
 
             $token = $this->dopost(config('msgraph.tenantUrlAccessToken'), $params);


### PR DESCRIPTION
Add 'ressource' in params in order to prevent the 'Access token validation failure. Invalid audience.' error