### PR TITLE
Rewrote MsGraphAdmin token methods

### DIFF
--- a/src/MsGraphAdmin.php
+++ b/src/MsGraphAdmin.php
@@ -152,10 +152,11 @@ class MsGraphAdmin
      */
     protected function storeToken($access_token, $refresh_token, $expires)
     {
-        //cretate a new record or if the user id exists update record
+        //Create or update a new record for admin token
         return MsGraphToken::updateOrCreate(['user_id' => null], [
+            'email'         => 'application_token', // Placeholder name
             'access_token'  => $access_token,
-            'expires'       => $expires,
+            'expires'       => (time() + $expires),
             'refresh_token' => $refresh_token,
         ]);
     }

--- a/src/MsGraphAdmin.php
+++ b/src/MsGraphAdmin.php
@@ -69,32 +69,21 @@ class MsGraphAdmin
      */
     public function connect()
     {
-        //when no code param redirect to Microsoft
-        if (! request()->has('tenant')) {
-            $url = config('msgraph.tenantUrlAuthorize').'?'.http_build_query([
-                'client_id'    => config('msgraph.clientId'),
-                'redirect_uri' => config('msgraph.redirectUri'),
-            ]);
+        try {
+            $params = [
+                'scope'         => 'https://graph.microsoft.com/.default',
+                'client_id'     => config('msgraph.clientId'),
+                'client_secret' => config('msgraph.clientSecret'),
+                'grant_type'    => 'client_credentials',
+            ];
 
-            return redirect()->away($url);
-        } elseif (request()->has('tenant')) {
-            // With the authorization code, we can retrieve access tokens and other data.
-            try {
-                $params = [
-                    'scope'         => 'https://graph.microsoft.com/.default',
-                    'client_id'     => config('msgraph.clientId'),
-                    'client_secret' => config('msgraph.clientSecret'),
-                    'grant_type'    => 'client_credentials',
-                ];
+            $token = $this->dopost(config('msgraph.tenantUrlAccessToken'), $params);
 
-                $token = $this->dopost(config('msgraph.tenantUrlAccessToken'), $params);
+            // Store token
+            return $this->storeToken($token->access_token, '', $token->expires_in);
 
-                $this->storeToken($token->access_token, '', $token->expires_in);
-
-                return redirect(config('msgraph.msgraphLandingUri'));
-            } catch (Exception $e) {
-                die('error 90: '.$e->getMessage());
-            }
+        } catch (Exception $e) {
+            die('error 90: '.$e->getMessage());
         }
     }
 

--- a/src/MsGraphAdmin.php
+++ b/src/MsGraphAdmin.php
@@ -230,7 +230,7 @@ class MsGraphAdmin
         } catch (ClientException $e) {
             return json_decode(($e->getResponse()->getBody()->getContents()));
         } catch (Exception $e) {
-            return json_decode($e->getResponse()->getBody()->getContents(), true);
+            throw new Exception($e->getMessage());
         }
     }
 
@@ -248,7 +248,7 @@ class MsGraphAdmin
         } catch (ClientException $e) {
             return json_decode(($e->getResponse()->getBody()->getContents()));
         } catch (Exception $e) {
-            return json_decode($e->getResponse(), true);
+            throw new Exception($e->getMessage());
         }
     }
 


### PR DESCRIPTION
Had issues with getting admin tokens and sending mail and noted a few mistakes during debugging.

- getAccessToken() returned a redirection to the oath login page instead of getting a new token in the background.
- Oath returns the expiration time as duration rather than a timestamp, this is now stored properly

Not sure if it breaks any other parts of the package. I didn't change any methods names and everything is pretty much in the same flow.  

