### PR TITLE
Do not load migrations if table exists

### DIFF
--- a/src/MsGraphServiceProvider.php
+++ b/src/MsGraphServiceProvider.php
@@ -7,6 +7,7 @@ use Dcblogdev\MsGraph\Console\Commands\MsGraphKeepAliveCommand;
 use GuzzleHttp\Client;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use League\Flysystem\Filesystem;
@@ -23,7 +24,9 @@ class MsGraphServiceProvider extends ServiceProvider
      */
     public function boot(Router $router)
     {
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        if (! Schema::hasTable('ms_graph_tokens')) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        }
         $this->registerCommands();
         $this->registerMiddleware($router);
         $this->configurePublishing();


### PR DESCRIPTION
Upon publishing the migrations and running the tests, I observed a failure occurring when it attempted to generate the table twice. Therefore, I am currently working on resolving this bug.

With version 3.1.9 it works fine. After upgrading to 3.2.0 I encountered this problem.