### PR TITLE
Don't run migrations automatically

### DIFF
--- a/src/MsGraphServiceProvider.php
+++ b/src/MsGraphServiceProvider.php
@@ -23,7 +23,6 @@ class MsGraphServiceProvider extends ServiceProvider
      */
     public function boot(Router $router)
     {
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->registerCommands();
         $this->registerMiddleware($router);
         $this->configurePublishing();


### PR DESCRIPTION
We have an application that uses a multi-tenant database setup, which means each tenant has their own database. Currently, this package always runs the migrations when running `php artisan migrate`. We don't want this table migrated in the central database but in the tenant database. Currently, I cannot prevent it from running.

Most packages give the user the option to publish the migrations and then run then when needed, I think this package should follow this convention.