### PR TITLE
fix: search a token with a refresh token filled

### DIFF
--- a/src/MsGraph.php
+++ b/src/MsGraph.php
@@ -203,7 +203,7 @@ class MsGraph
     public function getTokenData($id = null)
     {
         $id = $this->getUserId($id);
-        return MsGraphToken::where('user_id', $id)->first();
+        return MsGraphToken::where('user_id', $id)->where('refresh_token', '<>', '')->first();
     }
 
     /**

--- a/tests/MsGraphTest.php
+++ b/tests/MsGraphTest.php
@@ -30,6 +30,7 @@ test('is connected returns true when a valid token exists', function () {
     MsGraphToken::create([
         'user_id'      => $userId,
         'access_token' => 'ghgh4h22',
+        'refresh_token' => 'rhrh4h22',
         'expires'      => strtotime('+1 day'),
     ]);
 


### PR DESCRIPTION
Context:
User token has a refresh token filled in 'ms_graph_tokens' table.
Application token doesn't have refresh token in 'ms_graph_tokens' table.

Probleme:
if an 'Application token' is created in the 'ms_graph_tokens' table and If the $id in the function getTokenData is egal to 'null' the MsGraphToken model returned is the 'Application token'. This is not correct