### PR TITLE
Fix: Add string as argument type to isJson function

### DIFF
--- a/src/MsGraphAdmin.php
+++ b/src/MsGraphAdmin.php
@@ -162,7 +162,7 @@ class MsGraphAdmin
         }
     }
 
-    protected function isJson(object $data): bool
+    protected function isJson(object|string $data): bool
     {
         return is_string($data) && is_array(json_decode($data, true)) && (json_last_error() == JSON_ERROR_NONE);
     }


### PR DESCRIPTION
The function isJson is supposed to check if the result is a string or a json object. So it needs to accept strings.