### PR TITLE
Fix: Cross Origin Authorization Error.

### DIFF
--- a/src/MsGraph.php
+++ b/src/MsGraph.php
@@ -124,7 +124,7 @@ class MsGraph
 
                 $errorMessage = "{$response['error']} {$response['error_description']}\n".
                     'Error Code: '.($response['error_codes'][0] ?? 'N/A')."\n".
-                    "More Info: {$response['error_uri']}";
+                    'More Info: '.($response['error_uri'] ?? 'N/A');
 
                 throw new Exception($errorMessage);
             }

--- a/src/MsGraph.php
+++ b/src/MsGraph.php
@@ -28,32 +28,32 @@ class MsGraph
 {
     public function contacts(): Contacts
     {
-        return new Contacts();
+        return new Contacts;
     }
 
     public function emails(): Emails
     {
-        return new Emails();
+        return new Emails;
     }
 
     public function files(): Files
     {
-        return new Files();
+        return new Files;
     }
 
     public function sites(): Sites
     {
-        return new Sites();
+        return new Sites;
     }
 
     public function tasklists(): TaskLists
     {
-        return new TaskLists();
+        return new TaskLists;
     }
 
     public function tasks(): Tasks
     {
-        return new Tasks();
+        return new Tasks;
     }
 
     protected static string $baseUrl = 'https://graph.microsoft.com/v1.0/';
@@ -83,7 +83,7 @@ class MsGraph
     {
         self::$userModel = $model;
 
-        return new static();
+        return new static;
     }
 
     /**
@@ -111,7 +111,15 @@ class MsGraph
         }
 
         if (! request()->has('code') && ! $this->isConnected($id)) {
-            return redirect($provider->getAuthorizationUrl());
+            $codeVerifier = bin2hex(random_bytes(32));
+            $codeChallenge = rtrim(
+                strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '='
+            );
+
+            return redirect($provider->getAuthorizationUrl([
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => 'S256',
+            ]));
         }
 
         if (request()->has('code')) {

--- a/tests/MsGraphTest.php
+++ b/tests/MsGraphTest.php
@@ -69,7 +69,7 @@ test('connect with invalid code throws IdentityProviderException', function () {
 
     MsGraphFacade::connect();
 
-})->throws(IdentityProviderException::class);
+})->throws(Exception::class);
 
 test('can connect with valid code', function () {
 


### PR DESCRIPTION
This __PR__ solves __AADSTS9002325__ Error Code, when you are trying to authenticate (connect) the user, and redirect to the authorization URL.

## Steps to produce
- Define the connect route

```php
Route::group([
'prefix' => 'msgraph',
], function () {
   Route::get('connect', AccountEmailConnect::class);
});
```

- Create the method

```php
use Dcblogdev\MsGraph\Facades\MsGraph;

public function __invoke()
{
  return MsGraph::connect();
}
```

- Access The URL
- Authorize The Account
- You will get the following Error Code message

![image](https://github.com/user-attachments/assets/82c1235e-c8a1-48c6-89eb-572189e951f2)

### Solution
This __PR__, add the code challenge param, into the authorization URL, in order to solve the above issue.

