### PR TITLE
bugfix: Return type for retrieving list of emails

### DIFF
--- a/src/Resources/Emails.php
+++ b/src/Resources/Emails.php
@@ -109,7 +109,7 @@ class Emails extends MsGraph
     /**
      * @throws Exception
      */
-    public function get(string $folderId = '', array $params = []): MsGraph
+    public function get(string $folderId = '', array $params = []): array
     {
         $top = request('top', $this->top);
         $skip = request('skip', $this->skip);


### PR DESCRIPTION
This should hopefully fix an issue with the expected return type when using the `MsGraph::emails()->get()` method.

I hope this helps with Issue #93 