### PR TITLE
added methods

### DIFF
--- a/docs/v3/msgraph/emails.md
+++ b/docs/v3/msgraph/emails.md
@@ -170,7 +170,7 @@ MsGraph::emails()->findAttachment($id, $attachmentId);
 MsGraph::emails()->markAsRead($id);
 ```
 
-## Mark email as Unread
+## Mark email as unread
 
 ```php
 MsGraph::emails()->markAsUnread($id);

--- a/docs/v3/msgraph/emails.md
+++ b/docs/v3/msgraph/emails.md
@@ -136,12 +136,44 @@ To view an email call **->find($id)** followed by the id of the email.
 MsGraph::emails()->find($id);
 ```
 
+> From version v4.0.6, mark email as read when viewing it.
+
+```php
+MsGraph::emails()->find($id, bool $markAsRead = false);
+```
+
 Retrieve the emails using singleValueExtendedProperties.
 
 ```php
 MsGraph::emails()->get([
   '\$filter' => 'singleValueExtendedProperties/Any(ep: ep/id eq \'String {00020329-0000-0000-C000-000000000046} Name CustomProperty\' and ep/value eq \'CustomValue\')'
 ]);
+```
+
+## Get Email Attachments
+
+Get email attachments
+```php
+MsGraph::emails()->findAttachment($id);
+```
+
+## Get Email Attachment
+
+Get email attachment by its id
+```php
+MsGraph::emails()->findAttachment($id, $attachmentId);
+```
+
+## Mark email as read
+
+```php
+MsGraph::emails()->markAsRead($id);
+```
+
+## Mark email as Unread
+
+```php
+MsGraph::emails()->markAsUnread($id);
 ```
 
 ## Send Email

--- a/src/Resources/Emails/Emails.php
+++ b/src/Resources/Emails/Emails.php
@@ -151,14 +151,23 @@ class Emails extends MsGraph
         }
     }
 
-    public function find(string $id): array
+    public function find(string $id, bool $markAsRead = false): array
     {
+        if ($markAsRead) {
+            self::markAsRead($id);
+        }
+
         return MsGraph::get('me/messages/'.$id);
     }
 
     public function findAttachments(string $id): array
     {
         return MsGraph::get('me/messages/'.$id.'/attachments');
+    }
+
+    public function findAttachment(string $id, string $attachmentId): array
+    {
+        return MsGraph::get('me/messages/'.$id.'/attachments/'.$attachmentId);
     }
 
     public function findInlineAttachments(array $email): array
@@ -190,6 +199,16 @@ class Emails extends MsGraph
         );
 
         return $email;
+    }
+
+    public function markAsRead(string $id): void
+    {
+        MsGraph::patch('me/messages/'.$id, ['isRead' => true]);
+    }
+
+    public function markAsUnread(string $id): void
+    {
+        MsGraph::patch('me/messages/'.$id, ['isRead' => false]);
     }
 
     /**


### PR DESCRIPTION
## New methods added:

Mark email as read
```php
MsGraph::emails()->markAsRead(string $id);
```
Mark email as Unread
```php
MsGraph::emails()->markAsUnread(string $id);
```
Get email attachment by its id
```php
MsGraph::emails()->findAttachment(string $id, string $attachmentId);
```

## Methods updated

Find email can now mark email as read when set to true
```php
MsGraph::emails()->find(string $id, bool $markAsRead = false);
```

