### PR TITLE
Switched to the correct type

### DIFF
--- a/src/MsGraphServiceProvider.php
+++ b/src/MsGraphServiceProvider.php
@@ -7,6 +7,7 @@ use Dcblogdev\MsGraph\Console\Commands\MsGraphKeepAliveCommand;
 use Dcblogdev\MsGraph\Facades\MsGraph as MsGraphFacade;
 use GuzzleHttp\Client;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
@@ -65,7 +66,7 @@ class MsGraphServiceProvider extends ServiceProvider
 
     public function registerFilesystem(): void
     {
-        Storage::extend('msgraph', function (string $app, array $config) {
+        Storage::extend('msgraph', function (Application $app, array $config) {
             $graph = new Graph;
 
             if (MsGraphFacade::isConnected()) {


### PR DESCRIPTION
When installing the package and trying to get connected, my application tells me that I use the wrong argument type in the `Storage::extend()` method.

```
Dcblogdev\MsGraph\MsGraphServiceProvider::Dcblogdev\MsGraph\{closure}(): Argument #1 ($app) must be of type string, Illuminate\Foundation\Application given, called in /Users/stephan/Projects/playground/keurmerk-sharepoint/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemManager.php on line 162
/vendor/dcblogdev/laravel-microsoft-graph/src/MsGraphServiceProvider.php:69
 	/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemManager.php:162
 	 	 in Dcblogdev\MsGraph\MsGraphServiceProvider::Dcblogdev\MsGraph\{closure}()
 	/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemManager.php:142
 	 	 in Illuminate\Filesystem\FilesystemManager::callCustomCreator()
 	/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemManager.php:119
 	 	 in Illuminate\Filesystem\FilesystemManager::resolve()
 	/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemManager.php:82
 	 	 in Illuminate\Filesystem\FilesystemManager::get()
 	/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:361
 	 	 in Illuminate\Filesystem\FilesystemManager::disk()
```

As stated in the [Laravel docs](https://laravel.com/docs/10.x/filesystem#custom-filesystems), the `extend` method accepts the Application instance as first argument.
I changed the return type to `Illuminate\Foundation\Application`